### PR TITLE
Readme/Make_env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init help core down up logs 
+.PHONY: init help core down up logs logs-web logs-api logs-solr logs-nginx logs-le initdb-solr update-images nginx-restart
 
 include .env
 export $(shell sed 's/=.*//' .env)
@@ -6,12 +6,18 @@ export $(shell sed 's/=.*//' .env)
 help:
 	@echo "Help: "
 	@echo "init: submodule initialization and updates"
-	@echo "core: builds the derilinx_ckan core image "
 	@echo "down: brings the docker-compose set down "
 	@echo "up: brings the docker-compose set up "
-	@echo "logs: tails ckan logs "
-init:
+	@echo "logs | logs-web: tails webserver logs "
+	@echo "logs-solr: tails solr logs "
+	@echo "logs-api: tails api logs "
+	@echo "logs-nginx: tails nginx logs "
+	@echo "logs-le: tails nginx lets-encrypt "
+	@echo "initdb-solr: prepares the solr database "
+
+init: .env
 	git submodule update --init --recursive
+	$(MAKE) initdb-solr
 
 core: update-images
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
-## Basic NGINX
+## Single Machine OIH install
 
-A basic NGINX wrapper for our sites. This can be used as a bootstrap for wrapping any additional services in a docker-compose + nginx + nginx proxy stack.
+This is a docker-compose wrapper providing all of the services for the OIH search engine on one docker-compose stack for development or staging deployment.
 
-Edit `make-env.py` to add whatever you need to the environment file. It likely needs a HOST variable, at the very least.
+It includes
+* nginx-proxy as a web proxy to access the website and the api
+* A lets-encrypt sidecar for nginx-proxy to provide for certificates. If you are running on a local/non-internet accessible domain, this will silently fall back to HTTP rather than HTTPS.
+* Container definitons for the API, web, and solr instances.
 
+Running `make` will give a list of makefile commands of interest.
+
+
+To get started:
+
+```
+si:oih-ui-docker erics$ make init
+Makefile:3: .env: No such file or directory
+sed: .env: No such file or directory
+./make_env.py
+
+Making the ENV file...
+
+Hostname? oih.localhost
+git submodule update --init --recursive
+/Applications/Xcode.app/Contents/Developer/usr/bin/make initdb-solr
+docker-compose run -u root solr chown solr:solr /var/solr/data/ckan/data
+Creating oih-ui-docker_solr_run ... done
+si:oih-ui-docker erics$ make up
+```
+
+At this point, the system should be up and running, though without any indexed documents.
+
+
+## Settings Details
+
+The docker compose sets some environment variables that are important for connecting between the various services.
+
+### API
+
+The api is assumed to be at `api.hostname`, the website at `hostname` (as set in the .env file by make_env.py) This can be changed in the environment variables `VIRTUAL_HOST` for the proxy service and `LETSENCRYPT_HOST` for the lets-encrypt ssl cert. For development work, I find it useful to map `*.localhost` to my local machine, so `oih.localhost` and `api.oih.localhost` automatically resolve to my dev machine.
+
+If you change the API url, the setting for `REACT_APP_DATA_SERVICE_URL` in the web environment needs to be changed to match.
+
+### Solr
+
+The `SOLR_JAVA_MEM` setting may require tweaking to allow for more memory to be used by the solr process, depending on the machine size.

--- a/make_env.py
+++ b/make_env.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, sys, base64
 
 FILENAME='.env'
 
+def noop(s): return s
 def lower(s): return s.lower()
 def _bool(s):
     return {'t':'true',
@@ -11,10 +12,6 @@ def _bool(s):
             'f': 'false'}.get(s.lower(), s.lower())
 
 VARS = (('HOST', 'Hostname', lower),
-        ('PRODUCTION', 'Is this production (t/f)', _bool),
-        ('IMAGE_TAG', 'staging/prod', lower),
-        ('SITE_SCHEME', 'http/https', lower),
-        ('SHORT_CODE', 'shortecode for site, one word', lower)
         )
 
 def random_pw():
@@ -29,22 +26,19 @@ if os.path.exists(FILENAME):
     print (".env file exists, either remove or edit directly")
     sys.exit(0)
 
-vars = dict((var,_filter(raw_input(prompt + "? ").strip())) for var, prompt, _filter in VARS)
+vars = dict((var,_filter(input(prompt + "? ").strip())) for var, prompt, _filter in VARS)
 
-for pw in ('DB_ENV_POSTGRES_PASS',
-           'DB_ENV_DATASTORE_PASS',
-           'DB_ENV_DATASTORE_RO_PASS',
-           'ADMIN_PASSWORD',
-           'POSTGRES_PASSWORD',
-           'DB_ENV_SUPERSET_PASS',
-           'SUPERSET_SECRET',
-           'SUPERSET_SECRET_KEY'):
-    vars[pw] = random_pw()
+# for pw in ('DB_PASS',
+#            'POSTGRES_PASSWORD',
+#            'ADMIN_PASS'):
+#     vars[pw] = random_pw()
 
-with open (FILENAME, 'wa') as f:
-    for item in sorted(vars.items()):
-        f.write("%s=%s\n" % item)
+with open (FILENAME, 'w') as f:
+    for k,v in sorted(vars.items()):
+        strVal = v
+        if isinstance(v, bytes):
+            strVal=v.decode('ascii')
+        f.write("%s=%s\n" % (k,strVal))
 
-print ("\n\nAdmin Password: %s\n" % vars['ADMIN_PASSWORD'])
 
 sys.exit(0)


### PR DESCRIPTION
Fixes #1, #2, #5, #6

`make init` should now run out of the box on modern ubuntu with `make` installed to create the `.env` file and checkout the current versions of all of the submodules. 

`make up` or `docker-compose up -d` will bring up the site at that point.